### PR TITLE
Normalize spelling of "Aparte"

### DIFF
--- a/tei/el-alcaide-de-si-mismo.xml
+++ b/tei/el-alcaide-de-si-mismo.xml
@@ -910,7 +910,7 @@
           </sp>
           <sp who="#federico">
             <speaker rend="caps">Federico</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>A buen puerto vine yo.</l>
@@ -939,7 +939,7 @@
             <l>son una misma las dos:</l>
             <l>la merced que me ofrecéis</l>
             <l>de vivir con vos acepto,</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>(aquí viviré secreto)</l>
             <l>sirviéndoos, que bien sabéis</l>
             <l>que un hombre que rico ha sido,</l>
@@ -966,7 +966,7 @@
 
             <l>Qué prudente, y advertido</l>
             <l>su sentimiento mostró!</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>qué bien que disimuló</l>
             <l>el llanto mal resistido!</l>
             <l>Este hombre me ha obligado</l>
@@ -1064,7 +1064,7 @@
           </sp>
           <sp who="#elena">
             <speaker rend="caps">Elena</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Su modo dice que es</l>
@@ -1186,7 +1186,7 @@
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Qué rigor!</l>
@@ -1208,7 +1208,7 @@
             <l>Busca al traidor, harás bien,</l>
             <l>muerte tus manos le den:</l>
             <l>no lo permitan los Cielos.</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>Mas quien pretende olvidar</l>
             <l>una pena, o vanagloria,</l>
             <l>le sirve de más memoria</l>
@@ -1349,7 +1349,7 @@
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Mi agravio veo.</l>
@@ -1362,7 +1362,7 @@
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Mi muerte escucho.</l>
@@ -1398,7 +1398,7 @@
 
 
             <l>Oh Fedérico cruel:</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>(corazón, disimulemos,</l>
             <l>y estas lágrimas, y extremos</l>
             <l>hablen a un tiempo con él,)</l>
@@ -1406,7 +1406,7 @@
             <l>soberbio, y desvanecido,</l>
             <l>altivo, loco, atrevido,</l>
             <l>cuyo poder, cuya mano,</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>muerte me dio (y es verdad,</l>
             <l>muerte alevosa me dio,</l>
             <l>pues la vida me quitó,</l>
@@ -1481,7 +1481,7 @@
 
             <l>Y es bien que esté preso el fiero</l>
             <l>que a un enemigo sirvió:</l>
-            <stage>Ap. a Roberto</stage>
+            <stage>Aparte a Roberto</stage>
             <l>libertad te daré yo.</l>
           </sp>
           <sp who="#roberto">
@@ -2524,7 +2524,7 @@
           </sp>
           <sp who="#roberto">
             <speaker rend="caps">Roberto</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Qué es esto que escucho?</l>
@@ -2553,7 +2553,7 @@
           </sp>
           <sp who="#rey">
             <speaker rend="caps">Rey</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Dudoso</l>
@@ -2710,7 +2710,7 @@
             <l>que esté en la prisión desuerte,</l>
             <l>que sea digno hospedaje</l>
             <l>de un Príncipe tan valiente.</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>Ya como yerno le trato</l>
             <l>a mi enemigo.</l>
           </sp>
@@ -2736,7 +2736,7 @@
             <l>mil favores, y mercedes.</l>
             <l>Quiero componer las partes,</l>
             <l>por Margarita: o mujeres,</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>que de intentos descomponen</l>
             <l>vuestros necios pareceres!</l>
           </sp>
@@ -2748,7 +2748,7 @@
           </sp>
           <sp who="#benito">
             <speaker rend="caps">Benito</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Vamos (otro loco es este)</l>
@@ -2875,7 +2875,7 @@
           </sp>
           <sp who="#elena">
             <speaker rend="caps">Elena</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Ya conoce mis extremos,</l>
@@ -3341,7 +3341,7 @@
 
             <l>No tan despacio he venido,</l>
             <l>que sentarme haya querido:</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>yo he de empezar por aquí,</l>
             <l>una fineza por mí</l>
             <l>has de hacer.</l>
@@ -4155,7 +4155,7 @@
             <l>si tú no me lo mandaras.</l>
             <l>Direlo; porque me dio</l>
             <l>licencia tu voz, señora.</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>Bueno fuera que hasta ahora</l>
             <l>huviera callado yo.</l>
           </sp>
@@ -4248,7 +4248,7 @@
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Cielo, qué es lo que escucho?</l>
@@ -4261,7 +4261,7 @@
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Mal mi dolor resisto:</l>
@@ -4500,7 +4500,7 @@
           </sp>
           <sp who="#elena">
             <speaker rend="caps">Elena</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Bien comparada estoy.</l>
@@ -4972,13 +4972,13 @@
             <l>Qué presto</l>
             <l>concedió, y el alegría</l>
             <l>salió modesta a los ojos,</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>cómo a los labios en risa!</l>
             <l>mas disimular importa.</l>
           </sp>
           <sp who="#margarita">
             <speaker rend="caps">Margarita</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Si enamorada me mira</l>
@@ -5160,7 +5160,7 @@
 
             <l>Sí, mas sin darme porrazos,</l>
             <l>mas ya mi ingeño imagina</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>como he de vengarme de él,</l>
             <l>en teniendo compañía.</l>
           </sp>
@@ -5258,7 +5258,7 @@
           </sp>
           <sp who="#rey">
             <speaker rend="caps">Rey</speaker>
-            <stage type="withText">ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Qué mal callán, Margárita,</l>
@@ -5271,7 +5271,7 @@
             <l>Tu Majestad</l>
             <l>sabe bien dar honra, y vida</l>
             <l>a un preso que está sujeto:</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>el diabro me hizo discreto.</l>
           </sp>
           <sp who="#roberto">
@@ -5286,7 +5286,7 @@
 
 
             <l>De oírle así hablar me espanto:</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>ha poder, y mando, cuanto</l>
             <l>enmiendas el natural!</l>
           </sp>
@@ -5454,7 +5454,7 @@
           </sp>
           <sp who="#federico">
             <speaker rend="caps">Federico</speaker>
-            <stage type="withText">ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Bien su respuesta me anima.</l>
@@ -5756,7 +5756,7 @@
 
 
             <l>Déjame besar tus plantas;</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>lindamente me he vengado</l>
             <l>de los celos que me causa</l>
             <l>Margárita: amor vencí,</l>
@@ -5871,7 +5871,7 @@
           </sp>
           <sp who="#federico">
             <speaker rend="caps">Federico</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Sin que el engaño conozcan,</l>

--- a/tei/el-divino-jason-attributed.xml
+++ b/tei/el-divino-jason-attributed.xml
@@ -1046,7 +1046,7 @@
           </sp>
           <sp who="#idolatria">
             <speaker>IDOLATRÍA</speaker>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>(Amores finge; yo llego,</l>
             <l>y si verdaderos son,</l>
             <l>exhale mi corazón</l>

--- a/tei/la-cena-del-rey-baltasar-auto.xml
+++ b/tei/la-cena-del-rey-baltasar-auto.xml
@@ -475,7 +475,7 @@
           </sp>
           <sp who="#baltasar">
             <speaker>BALTASAR</speaker>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>(Un día me amanece en otro día,</l>
             <l n="215">y entre la Vanidad y Idolatría</l>
             <l>la más hermosa el alma temerosa</l>
@@ -2200,7 +2200,7 @@
           </sp>
           <sp who="#muerte">
             <speaker>MUERTE</speaker>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l part="F">(¡Ay de ti,</l>
             <l n="1370">que no sabes lo que hay dentro!)</l>
           </sp>

--- a/tei/la-cura-y-la-enfermedad.xml
+++ b/tei/la-cura-y-la-enfermedad.xml
@@ -1080,7 +1080,7 @@
           </sp>
           <sp who="#sombra">
             <speaker>SOMBRA</speaker>
-            <stage>Ap</stage>
+            <stage>Aparte.</stage>
             <l>(Yo te haré presto malicia.)</l>
           </sp>
           <sp who="#inociencia">
@@ -2691,7 +2691,7 @@
           <stage>Retírase.</stage>
           <sp who="#culpa">
             <speaker>CULPA</speaker>
-            <stage>Ap</stage>
+            <stage>Aparte.</stage>
             <l>Buena ignorancia es pensar</l>
             <l n="1240">que no están tocados ellos</l>
             <l>de su mismo mal; mas uno</l>
@@ -3460,7 +3460,7 @@
           </sp>
           <sp who="#lucero">
             <speaker>LUCERO</speaker>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l part="F">(Tiemblo al mirarle.)</l>
             <l>Compadecido de que</l>
             <l n="1610">padezcas ajenos males,</l>

--- a/tei/la-selva-confusa.xml
+++ b/tei/la-selva-confusa.xml
@@ -536,7 +536,7 @@
             <l>aun voy seguro sin ella;</l>
             <l part="I">(Adiós, Jacinta.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Vase.</stage>
           <sp who="#carlos">
             <speaker>CARLOS</speaker>
@@ -608,7 +608,7 @@
             <l>no viva en la tierra yo</l>
             <l>y en vuestras espumas muera.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#carlos">
             <speaker>CARLOS</speaker>
             <l>¡Qué gran valor ha mostrado!</l>
@@ -923,7 +923,7 @@
             <l part="F">(Aquí</l>
             <l>quién soy me importa callar.)</l>
           </sp>
-          <stage>Ap.</stage>
+          <stage>Aparte.</stage>
           <stage>Salen el Duque y Otavio.</stage>
           <sp who="#otavio">
             <speaker>OTAVIO</speaker>
@@ -2032,12 +2032,12 @@
             <speaker>FADRIQUE</speaker>
             <l>(¡Ay, si fueras siempreviva!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l>(¡Ay, si maravilla fueras!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
         </div>
 
 
@@ -2246,7 +2246,7 @@
             <l>pues que fingidos mis ojos</l>
             <l>linces vigilantes son.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l>¡Ay, Fadrique desdichado!</l>
@@ -2422,7 +2422,7 @@
             <l>mas nada concedo o niego</l>
             <l part="I">con irme.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l part="F">Fadrique, espera.</l>
@@ -2431,7 +2431,7 @@
             <speaker>FADRIQUE</speaker>
             <l>No soy Fadrique (¡Ay de mí!).</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l part="I">Pues, pescador.</l>
@@ -2515,7 +2515,7 @@
             <l>ha de ponerse en razón</l>
             <l>con tal imaginación?)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l part="I">¿Qué te parece?</l>
@@ -2724,7 +2724,7 @@
             <l>sin la gran puntualidad</l>
             <l>de la Corte y el palacio.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#filipo">
             <speaker>FILIPO</speaker>
             <l>¿La hermosa Flora no está</l>
@@ -2747,7 +2747,7 @@
             <l>que yo sé que conocéis</l>
             <l part="I">a Flora.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#filipo">
             <speaker>FILIPO</speaker>
             <l part="F">Nunca la vi.</l>
@@ -2784,7 +2784,7 @@
             <l>No, por cierto, y la excedéis.</l>
             <l>¿Sois Flora?(¡Decid que no!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#celia">
             <speaker>CELIA</speaker>
             <l>Fuera hacerme ofensa a mí</l>
@@ -2799,7 +2799,7 @@
             <l>corto en lo que he imaginado.</l>
             <l part="I">(Carlos.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#carlos">
             <speaker>CARLOS</speaker>
             <l part="M">(Señor.)</l>
@@ -2836,7 +2836,7 @@
             <l>Mas de Flora la locura</l>
             <l>al duque avisarle quiero.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Vase.</stage>
           <sp who="#carlos">
             <speaker>CARLOS</speaker>
@@ -3204,7 +3204,7 @@
             <speaker>JACINTA</speaker>
             <l>(El cielo mi intento ayuda.)</l>
           </sp>
-          <stage>Ap.</stage>
+          <stage>Aparte.</stage>
           <sp who="#otavio">
             <speaker>OTAVIO</speaker>
             <l>…que salio a este campo ahogado;</l>
@@ -3582,7 +3582,7 @@
             <l>si el mayor puede obligarte,</l>
             <l>escúchame un rato atento.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#oton">
             <speaker>OTÓN</speaker>
             <l>(De Celia viene advertido.)</l>
@@ -3605,7 +3605,7 @@
             <l>pues con esto mi ventura</l>
             <l>ni la dudo ni la temo.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l>Invidias de la fortuna</l>
@@ -3638,7 +3638,7 @@
             <speaker>FLORA</speaker>
             <l>De aquí mi ventura espero.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l part="I">Sabrás, pues, que soy…</l>
@@ -3660,7 +3660,7 @@
             <l>¿cómo pudiera? ¡Qué presto</l>
             <l part="I">se supo!</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l part="F">Pues él lo afirma,</l>
@@ -3712,7 +3712,7 @@
             <l>Bien temí su sentimiento.)</l>
             <l>Señor, yo callé quién era…</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
             <l part="I">Yo te lo perdono.</l>
@@ -4048,7 +4048,7 @@
         </div>
         <div type="scene" resp="#rojas" n="17">
           <stage>[Vase Otavio.]</stage>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#marcial">
             <speaker>MARCIAL</speaker>
             <l part="I">(Calla agora.)</l>
@@ -4105,7 +4105,7 @@
             <l>¿No es Jacinta esta que veo,</l>
             <l part="I">cielos?)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#jacinta">
             <speaker>JACINTA</speaker>
             <l part="F">Pues, ¿de qué has quedado</l>
@@ -4140,7 +4140,7 @@
             <l>aunque me ha buscado muerto.</l>
             <l part="I">¿Qué he de hacer?)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#jacinta">
             <speaker>JACINTA</speaker>
             <l part="F">No tenga empacho,</l>
@@ -4197,7 +4197,7 @@
             <l>Marcial es su nombre mesmo.</l>
             <l part="I">Esto es la verdad.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
             <l part="F">(¡Qué bien</l>
@@ -4229,12 +4229,12 @@
             <l>está, y con Flora! Yo creo</l>
             <l>que otro se lo habrá avisado.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l>De rabia y de celos muero.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Sale Otavio.</stage>
           <sp who="#otavio">
             <speaker>OTAVIO</speaker>
@@ -4303,7 +4303,7 @@
             <speaker>CELIA</speaker>
             <l>¡Qué bien finge el picarón!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l>Es justo agradecimiento,</l>
@@ -4317,7 +4317,7 @@
             <l>tan falto el entendimiento,</l>
             <l>que todo lo haya creído!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l>Aunque pienso agradecerlo,</l>
@@ -4640,7 +4640,7 @@
             <speaker>CELIA</speaker>
             <l part="I">¿Señora?)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l part="F">No replique Vuestra Alteza,</l>
@@ -4651,7 +4651,7 @@
             <speaker>CELIA</speaker>
             <l>Nunca tan grande fue mi atrevimiento.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
             <l>¿Su fama, su hermosura, su nobleza</l>
@@ -4661,14 +4661,14 @@
             <speaker>CELIA</speaker>
             <l part="F">Vengó mi fingimiento.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#filipo">
             <speaker>FILIPO</speaker>
             <l>Confuso estoy entre una y otra Flora;</l>
             <l>mas es la noche una, otra la aurora.)</l>
             <l part="I">(Carlos,…)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#carlos">
             <speaker>CARLOS</speaker>
             <l part="M">(¿Señor?)</l>
@@ -4765,7 +4765,7 @@
             <l>de la naturaleza varia creo</l>
             <l>que sacó dos estampas en un día.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#filipo">
             <speaker>FILIPO</speaker>
             <l>(Rendido voy a manos de un deseo:</l>
@@ -4784,7 +4784,7 @@
             <l>Él es. Direlo al duque, y que ha venido</l>
             <l>como su embajador disimulado.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Vase.</stage>
           <sp who="#flora">
             <speaker>FLORA</speaker>
@@ -4870,7 +4870,7 @@
             <speaker>CELIA</speaker>
             <l>Ya se vuelve a su locura.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Sale Fadrique.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
@@ -4949,7 +4949,7 @@
             <speaker>CELIA</speaker>
             <l>¿Qué enredo mayor es éste?)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l part="I">Déjame hablar.</l>
@@ -5104,7 +5104,7 @@
             <l>Flora; pero yo lo estuve</l>
             <l>en reírme y no creerte.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Vase Celia.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
@@ -5346,7 +5346,7 @@
             <speaker>FADRIQUE</speaker>
             <l>Esto sólo me faltaba.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
             <l>(¡A qué buen tiempo ha llegado</l>
@@ -5377,7 +5377,7 @@
             <speaker>FADRIQUE</speaker>
             <l>Confieso que loco estoy.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#jacinta">
             <speaker>JACINTA</speaker>
             <l>Él tiene perdido el seso.</l>
@@ -5410,7 +5410,7 @@
             <l>y callando, porque entiendo</l>
             <l>que han de decir que estoy loco!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#jacinta">
             <speaker>JACINTA</speaker>
             <l>Señor, déjele ir a casa,</l>
@@ -5429,7 +5429,7 @@
             <speaker>DUQUE</speaker>
             <l>¡Qué bien que le contradice!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l>Jacinta, si piensas hoy</l>
@@ -5582,7 +5582,7 @@
             <l part="F">(¡Ah, crüel,</l>
             <l>bien los celos me has pagado!)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <stage>Va[n]se Jacinta y Marcial.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
@@ -6136,7 +6136,7 @@
             <speaker>FILIPO</speaker>
             <l>Sin mí y conmigo vivo.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
             <l>(A ejecutarlo estoy determinado.)</l>
@@ -6152,7 +6152,7 @@
             <l>el alma, que desea</l>
             <l>ser suya, o ya sea Flora o Celia sea.</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#celia">
             <speaker>CELIA</speaker>
             <l>(¿Qué hemos de hacer, señora,</l>
@@ -6406,7 +6406,7 @@
             <l>tus cortesanos adornos</l>
             <l>en rústicas ropas muda?</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#jacinta">
             <speaker>JACINTA</speaker>
             <l>¡Filipo es este, ay de mí!</l>
@@ -6414,7 +6414,7 @@
             <l>el engaño de Fadrique</l>
             <l>que mejor me disimula.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#filipo">
             <speaker>FILIPO</speaker>
             <l>Si de tu rigor, Jacinta,</l>
@@ -6717,7 +6717,7 @@
             <l>dama de hijo de familias:</l>
             <l>¡mira si es desnudez suma!</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#duque">
             <speaker>DUQUE</speaker>
             <l part="I">Dilo, acaba.</l>
@@ -6835,7 +6835,7 @@
             <l>Mas, ¿qué fortuna alcanza</l>
             <l>a costa de su daño la venganza?</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#oton">
             <speaker>OTÓN</speaker>
             <l part="I">(Allí Fadrique está.)</l>
@@ -6881,7 +6881,7 @@
             <speaker>CELIA</speaker>
             <l>Sin duda que Fadrique perdió el seso.)</l>
           </sp>
-          <stage>[Ap.]</stage>
+          <stage>Aparte.</stage>
           <sp who="#fadrique">
             <speaker>FADRIQUE</speaker>
             <l part="I">Tirso.</l>

--- a/tei/la-senora-y-la-criada.xml
+++ b/tei/la-senora-y-la-criada.xml
@@ -3467,7 +3467,7 @@
 
             <l>Señora, yo:</l>
             <l>Lisardo a perder me echó!</l>
-            <stage>Ap.</stage>
+            <stage>Aparte</stage>
             <l>solo sé que soy fiel</l>
             <l>criado tuyo, y que sería,</l>
             <l>digo yo, algún jardinero,</l>
@@ -4902,7 +4902,7 @@
 
             <l>Este es Crotaldo, y nada ignora,</l>
             <l>ya sin duda sabia,</l>
-            <stage>Ap.</stage>
+            <stage>Aparte</stage>
             <l>que Diana venía,</l>
             <l>y que cayó también, pues que pregunta</l>
             <l>por ella.</l>
@@ -5521,7 +5521,7 @@
 
             <l>Qué es lo que mis ojos ven?</l>
             <l>aquí Diana! aquí Fabio!</l>
-            <stage>Ap.</stage>
+            <stage>Aparte</stage>
             <l>cielos, cómo puede ser?</l>
           </sp>
           <sp who="#crotaldo">
@@ -5590,7 +5590,7 @@
 
             <l>Pues me ha dado la vida Flor,</l>
             <l>por darme la muerte, haré</l>
-            <stage>ap.</stage>
+            <stage>Aparte</stage>
             <l>la desecha: Ya, señor,</l>
             <l>que es tan injusta, y cruel</l>
             <l>mi suerte, que en tanto mal,</l>
@@ -6409,7 +6409,7 @@
             <l>El Duque; válgame el cielo!</l>
             <l>viene al cuarto de Diana:</l>
             <l>Así he de disimular</l>
-            <stage>Ap.</stage>
+            <stage>Aparte</stage>
             <l>que di licencia de hablarla.</l>
             <l>Crotaldo, que atrevimiento</l>
             <l>es este? tú en esta sala?</l>

--- a/tei/los-tres-afectos-de-amor-piedad-desmayo-y-valor.xml
+++ b/tei/los-tres-afectos-de-amor-piedad-desmayo-y-valor.xml
@@ -2012,7 +2012,7 @@
           </sp>
           <sp who="#seleuco">
             <speaker rend="caps">Seleuco</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>Espera; que Anteo</l>
@@ -2042,7 +2042,7 @@
 
             <l>El Cielo os guarde: qué hombre</l>
             <l>Cloris, tan vano, y soberbio!</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>horror me ha dado el mirarle.</l>
           </sp>
           <sp who="#seleuco">
@@ -3381,7 +3381,7 @@
             <l>ni aún la lisonja pequeña</l>
             <l>de estimarla, o de sentirla,</l>
             <l>pase la duda a evidencia;</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>aunque, habiendo de ser otro,</l>
             <l>que sea Libio no me pesa,</l>
             <l>es fuerza disimular.</l>
@@ -5212,7 +5212,7 @@
             <l>tenga en mi servicio hecha</l>
             <l>mayor fineza, será</l>
             <l>a quien mi mano le ofrezca:</l>
-            <stage>Ap.</stage>
+            <stage>Aparte.</stage>
             <l>esto es dar tiempo a que viva</l>
             <l>una esperanza tan muerta.</l>
           </sp>
@@ -6956,7 +6956,7 @@
           </sp>
           <sp who="#ismenia">
             <speaker rend="caps">Ismenia</speaker>
-            <stage type="withText">Ap.</stage>
+            <stage type="withText">Aparte.</stage>
 
 
             <l>En manos di de Rosarda.</l>
@@ -9018,8 +9018,8 @@
             <l>de quien más humilde siempre,</l>
             <l>cuando hierra en lo que escribe,</l>
             <l>acierta en lo que obedece.</l>
-            <stage>FIN</stage>
           </sp>
+          <trailer>FIN</trailer>
         </div>
 
       </div>

--- a/tei/tambien-hay-duelo-en-las-damas.xml
+++ b/tei/tambien-hay-duelo-en-las-damas.xml
@@ -10025,7 +10025,7 @@
 
 
             <l>No me dirás, por lo menos,</l>
-            <stage>Ap. [a ella.]</stage>
+            <stage>Aparte [a ella.]</stage>
             <l>que no finjo bien tu engaño.</l>
             <l>Dime, Leonor ¿qué se ha hecho?</l>
           </sp>
@@ -10034,7 +10034,7 @@
 
 
             <l>Pues ¿qué sé yo de Leonor?</l>
-            <stage>[Ap. a él.]</stage>
+            <stage>[Aparte a él.]</stage>
             <l>(¿Quién se vio en igual aprieto?</l>
             <l>Si convengo con don Juan,</l>
             <l>que presume que yo he hecho</l>

--- a/tei/un-castigo-en-tres-venganzas.xml
+++ b/tei/un-castigo-en-tres-venganzas.xml
@@ -5093,7 +5093,7 @@
           </sp>
           <sp who="#flor">
             <speaker rend="caps">Flor</speaker>
-            <stage type="withText">[Ap.]</stage>
+            <stage type="withText">[Aparte.]</stage>
 
 
             <l/>


### PR DESCRIPTION
Normalized the spelling for "aparte" following the general orthographic efforts of the edition.